### PR TITLE
Include stack trace with each error

### DIFF
--- a/lua/autorun/server/error_logger.lua
+++ b/lua/autorun/server/error_logger.lua
@@ -111,22 +111,27 @@ hook.Add("Initialize", Identifier, function()
 	hook.Remove("Initialize", Identifier)
 end)
 
-hook.Add("LuaError", Identifier, function(_, Error, File, _, _, Stack)
+local function FullError(Error, Stack)
 	for k, v in ipairs(Stack) do
 		if k > 1 then
-			Error = Error .. string.format("\n%s%s. %s - %s:%s", string.rep("  ", k - 1), k - 1, v.name ~= "" and v.name or "unknown", v.short_src, v.currentline)
+			local StackNum = k - 1
+			local Indent = string.rep("  ", StackNum)
+			local FuncName = v.name ~= "" and v.name or "unknown"
+			Error = Error .. string.format("\n%s%s. %s - %s:%s", Indent, StackNum, FuncName, v.short_src, v.currentline)
 		end
 	end
+
+	return Error
+end
+
+hook.Add("LuaError", Identifier, function(_, Error, File, _, _, Stack)
+	Error = FullError(Error, Stack)
 
 	SaveError(File, "server", Error)
 end)
 
 hook.Add("ClientLuaError", Identifier, function(_, Error, File, _, _, Stack)
-	for k, v in ipairs(Stack) do
-		if k > 1 then
-			Error = Error .. string.format("\n%s%s. %s - %s:%s", string.rep("  ", k - 1), k - 1, v.name ~= "" and v.name or "unknown", v.short_src, v.currentline)
-		end
-	end
+	Error = FullError(Error, Stack)
 
 	SaveError(File, "client", Error)
 end)

--- a/lua/autorun/server/error_logger.lua
+++ b/lua/autorun/server/error_logger.lua
@@ -111,11 +111,23 @@ hook.Add("Initialize", Identifier, function()
 	hook.Remove("Initialize", Identifier)
 end)
 
-hook.Add("LuaError", Identifier, function(_, Error, File)
+hook.Add("LuaError", Identifier, function(_, Error, File, _, _, Stack)
+	for k, v in ipairs(Stack) do
+		if k > 1 then
+			Error = Error .. string.format("\n%s%s. %s - %s:%s", string.rep("  ", k - 1), k - 1, v.name ~= "" and v.name or "unknown", v.short_src, v.currentline)
+		end
+	end
+
 	SaveError(File, "server", Error)
 end)
 
-hook.Add("ClientLuaError", Identifier, function(_, Error, File)
+hook.Add("ClientLuaError", Identifier, function(_, Error, File, _, _, Stack)
+	for k, v in ipairs(Stack) do
+		if k > 1 then
+			Error = Error .. string.format("\n%s%s. %s - %s:%s", string.rep("  ", k - 1), k - 1, v.name ~= "" and v.name or "unknown", v.short_src, v.currentline)
+		end
+	end
+
 	SaveError(File, "client", Error)
 end)
 


### PR DESCRIPTION
Follows identical format to the stack traces the console provides.

Example:
```
Times detected: 1 time(s)
addons/cfw/lua/cfw/core/connectivity_sv.lua:65: attempt to index local 'link' (a nil value)
  1. disconnect - addons/cfw/lua/cfw/core/connectivity_sv.lua:65
    2. SetParent - addons/cfw/lua/cfw/core/parenting_sv.lua:19
      3. Function - lua/autorun/parent_childtables.lua:26
        4. v - lua/includes/extensions/entity.lua:146
          5. unknown - lua/includes/modules/hook.lua:96
```